### PR TITLE
[release] bumped scim-schema version to snapshot after released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>scim-schema</artifactId>
-            <version>1.3.1</version>
+            <version>1.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This pull request change the release-version to snapshot
