### PR TITLE
Replace dependency to scim-schema with connector4java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
     <dependencies>
         <dependency>
             <groupId>org.osiam</groupId>
-            <artifactId>scim-schema</artifactId>
-            <version>1.6</version>
+            <artifactId>connector4java</artifactId>
+            <version>1.9-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
`scim-schema` has been deprecated. Everything is contained in the
connector now.