### PR TITLE
Change version to 'latest-SNAPSHOT'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Replace dependency on scim-schema with connector4java
+- The current snapshot version is now `latest-SNAPSHOT` for all upcoming versions.
 
 ### Updates
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.osiam</groupId>
     <artifactId>addon-self-administration-plugin-api</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>latest-SNAPSHOT</version>
 
     <name>Plugin API registration</name>
     <description>The plugin API registration for the OSIAM addon-self-administration</description>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>connector4java</artifactId>
-            <version>1.9.CR1</version>
+            <version>latest-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This has to be done for the new release process to work. Otherwise we would
have to increase the version somehow after release by Circle CI or worse:
manually. There is no need to fetch a snapshot after a release, because the
release contains the exact same code as the last snapshot. So having a
universally working snapshot version, like
'latest-SNAPSHOT', should do no harm, but eases the burden of maintaining
the right version between releases.

Depends on https://github.com/osiam/connector4java/pull/226